### PR TITLE
Feat treeshaking surrpot exclude patterns

### DIFF
--- a/.changeset/four-dragons-send.md
+++ b/.changeset/four-dragons-send.md
@@ -1,0 +1,14 @@
+---
+'@xhsfe/babel-plugin-tree-shaking': patch
+'@xhsfe/metro-plugin-tree-shaking': patch
+---
+
+feat: treeShaking support `excludePatterns` optional paramater
+
+Example:
+
+```js [babel.config.js]
+module.exports = {
+  presets: [['module:@xhsfe/metro-plugin-tree-shaking', { excludePatterns: [new RegExp('/react/')] }]],
+}
+```

--- a/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
+++ b/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
@@ -206,14 +206,11 @@ module.exports = function plugin(api, options) {
   } = options
 
   const allExcludePatterns = [...defaultExcludePatterns, ...excludePatterns]
-  const excludePattern = allExcludePatterns.join('|')
-  const excludeRegex = new RegExp(excludePattern)
 
-
-    // 检查文件是否应该被排除
-    function shouldExclude(filename) {
-      return allExcludePatterns.some(pattern => pattern.test(filename));
-    }
+  // check if the file should be excluded
+  function shouldExclude(filename) {
+    return allExcludePatterns.some(pattern => pattern.test(filename));
+  }
 
   return {
     visitor: {

--- a/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
+++ b/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
@@ -183,7 +183,7 @@ const getOriginExportLoc = (
   }
 }
 
-  // 默认排除规则
+  // default exclude patterns
   const defaultExcludePatterns = [
     /react-native-url-polyfill/,
     /polyfills/,
@@ -200,25 +200,18 @@ module.exports = function plugin(api, options) {
   if (!fs.existsSync(DEFAULT_ROOT)) {
     fs.mkdirSync(DEFAULT_ROOT, { recursive: true })
   }
-    // 合并用户自定义的排除规则
+    // merge user custom exclude patterns
   const {
     excludePatterns = [],
   } = options
 
-    
-  console.log(excludePatterns, 'excludePatterns')
   const allExcludePatterns = [...defaultExcludePatterns, ...excludePatterns]
   const excludePattern = allExcludePatterns.join('|')
   const excludeRegex = new RegExp(excludePattern)
-  console.log(excludeRegex, 'excludeRegex')
-
 
 
     // 检查文件是否应该被排除
     function shouldExclude(filename) {
-      if (filename.includes('asgard')) {
-        console.log(filename, 'filename', allExcludePatterns.some(pattern => pattern.test(filename)))
-      }
       return allExcludePatterns.some(pattern => pattern.test(filename));
     }
 

--- a/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
+++ b/packages/babel-plugin-tree-shaking/src/tree-shaking-plugin.js
@@ -183,10 +183,45 @@ const getOriginExportLoc = (
   }
 }
 
+  // 默认排除规则
+  const defaultExcludePatterns = [
+    /react-native-url-polyfill/,
+    /polyfills/,
+    /@babel\/runtime/,
+    /metro-runtime\/src\/modules\/asyncRequire\.js/,
+    /@react-native\/asset-registry/,
+    /\.cjs(\.js)?$/,
+    /react-native\/Libraries\/Image\/AssetRegistry\.js/,
+    /jsx-runtime\./,
+  ]
+
+
 module.exports = function plugin(api, options) {
   if (!fs.existsSync(DEFAULT_ROOT)) {
     fs.mkdirSync(DEFAULT_ROOT, { recursive: true })
   }
+    // 合并用户自定义的排除规则
+  const {
+    excludePatterns = [],
+  } = options
+
+    
+  console.log(excludePatterns, 'excludePatterns')
+  const allExcludePatterns = [...defaultExcludePatterns, ...excludePatterns]
+  const excludePattern = allExcludePatterns.join('|')
+  const excludeRegex = new RegExp(excludePattern)
+  console.log(excludeRegex, 'excludeRegex')
+
+
+
+    // 检查文件是否应该被排除
+    function shouldExclude(filename) {
+      if (filename.includes('asgard')) {
+        console.log(filename, 'filename', allExcludePatterns.some(pattern => pattern.test(filename)))
+      }
+      return allExcludePatterns.some(pattern => pattern.test(filename));
+    }
+
   return {
     visitor: {
       Program: {
@@ -195,19 +230,7 @@ module.exports = function plugin(api, options) {
             // ignore polyfills & babel runtimes
             if (
               process.env.DISABLE_OPTIMIZE
-              || state.filename.includes('react-native-url-polyfill')
-              || state.filename.includes('polyfills')
-              || state.filename.includes('@babel/runtime')
-              || state.filename.includes('metro-runtime/src/modules/asyncRequire.js')
-              || state.filename.includes('@react-native/asset-registry')
-              // ignore cjs
-              || state.filename.endsWith('.cjs')
-              || state.filename.endsWith('.cjs.js')
-              || state.filename.includes(
-                'react-native/Libraries/Image/AssetRegistry.js',
-              )
-              // jsx-runtime.js || jsx-runtime.production.min.js
-              || state.filename.includes('jsx-runtime.')
+              || shouldExclude(state.filename)
             ) {
               return
             }

--- a/packages/metro-plugin-tree-shaking/__test__/__snapshots__/exclude.test.ts.snap
+++ b/packages/metro-plugin-tree-shaking/__test__/__snapshots__/exclude.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`exclude path 1`] = `
+"[
+	{
+		"count": 1,
+		"removed": true,
+		"value": "//# sourceMappingURL=origin.jsbundle.map"
+	},
+	{
+		"count": 1,
+		"added": true,
+		"value": "//# sourceMappingURL=optimize.jsbundle.map"
+	}
+]"
+`;

--- a/packages/metro-plugin-tree-shaking/__test__/__snapshots__/export-default-to-string.spec.ts.snap
+++ b/packages/metro-plugin-tree-shaking/__test__/__snapshots__/export-default-to-string.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`use import specifier to rename lib's named export 1`] = `
 	{
 		"count": 17,
 		"removed": true,
-		"value": "function stringIfy(obj) {\\nreturn JSON.stringify(obj, function (key, value) {\\nvar fnBody;\\nif (value instanceof Function || typeof value === 'function') {\\nfnBody = value.toString();\\nif (fnBody.length < 8 || fnBody.substring(0, 8) !== 'function') {\\n// this is ES6 Arrow Function\\nreturn \\"_NuFrRa_\\" + fnBody;\\n}\\nreturn fnBody;\\n}\\nif (value instanceof RegExp) {\\nreturn \\"_PxEgEr_\\" + value;\\n}\\nreturn value;\\n});\\n}\\n"
+		"value": "function stringIfy(obj) {\\nreturn JSON.stringify(obj, function (key, value) {\\nvar fnBody;\\nif (value instanceof Function || typeof value === 'function') {\\nfnBody = value.toString();\\nif (fnBody.length < 8 || fnBody.substring(0, 8) !== 'function') {\\n// this is ES6 Arrow Function\\nreturn \`_NuFrRa_\${fnBody}\`;\\n}\\nreturn fnBody;\\n}\\nif (value instanceof RegExp) {\\nreturn \`_PxEgEr_\${value}\`;\\n}\\nreturn value;\\n});\\n}\\n"
 	},
 	{
 		"count": 1,

--- a/packages/metro-plugin-tree-shaking/__test__/__snapshots__/export-default-to-string.spec.ts.snap
+++ b/packages/metro-plugin-tree-shaking/__test__/__snapshots__/export-default-to-string.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`use import specifier to rename lib's named export 1`] = `
 	{
 		"count": 17,
 		"removed": true,
-		"value": "function stringIfy(obj) {\\nreturn JSON.stringify(obj, function (key, value) {\\nvar fnBody;\\nif (value instanceof Function || typeof value === 'function') {\\nfnBody = value.toString();\\nif (fnBody.length < 8 || fnBody.substring(0, 8) !== 'function') {\\n// this is ES6 Arrow Function\\nreturn \`_NuFrRa_\${fnBody}\`;\\n}\\nreturn fnBody;\\n}\\nif (value instanceof RegExp) {\\nreturn \`_PxEgEr_\${value}\`;\\n}\\nreturn value;\\n});\\n}\\n"
+		"value": "function stringIfy(obj) {\\nreturn JSON.stringify(obj, function (key, value) {\\nvar fnBody;\\nif (value instanceof Function || typeof value === 'function') {\\nfnBody = value.toString();\\nif (fnBody.length < 8 || fnBody.substring(0, 8) !== 'function') {\\n// this is ES6 Arrow Function\\nreturn \\"_NuFrRa_\\" + fnBody;\\n}\\nreturn fnBody;\\n}\\nif (value instanceof RegExp) {\\nreturn \\"_PxEgEr_\\" + value;\\n}\\nreturn value;\\n});\\n}\\n"
 	},
 	{
 		"count": 1,

--- a/packages/metro-plugin-tree-shaking/__test__/exclude.test.ts
+++ b/packages/metro-plugin-tree-shaking/__test__/exclude.test.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'child_process'
+import 'colors'
+import fs from 'fs'
+import path from 'path'
+import { diffLines } from 'diff'
+
+test('exclude path', () => {
+  const METRO_TREE_SHAKING_CACHE_ROOT = path.join(__dirname, '../.optimize/exclude')
+  const OUTPUT_ROOT = path.join(__dirname, '../dist/exclude')
+  const ENTRY_FILE = './__test__/exclude.ts'
+  const BUNDLE_OUTPUT = './dist/exclude'
+
+  if (fs.existsSync(OUTPUT_ROOT)) {
+    fs.rmSync(OUTPUT_ROOT, { recursive: true })
+  }
+
+  fs.mkdirSync(OUTPUT_ROOT, { recursive: true })
+
+  if (fs.existsSync(METRO_TREE_SHAKING_CACHE_ROOT)) {
+    fs.rmSync(METRO_TREE_SHAKING_CACHE_ROOT, { recursive: true })
+  }
+
+  execSync(
+    `PRE_BUILD=1 METRO_TREE_SHAKING_CACHE_ROOT=${METRO_TREE_SHAKING_CACHE_ROOT} react-native bundle --platform=native --entry-file=${ENTRY_FILE} --bundle-output=${BUNDLE_OUTPUT}/main.jsbundle --sourcemap-output=${BUNDLE_OUTPUT}/main.jsbundle.map --dev=true`
+  )
+
+  execSync(
+    `DISABLE_OPTIMIZE=1 METRO_TREE_SHAKING_CACHE_ROOT=${METRO_TREE_SHAKING_CACHE_ROOT} react-native bundle --platform=native --entry-file=${ENTRY_FILE} --bundle-output=${BUNDLE_OUTPUT}/origin.jsbundle --sourcemap-output=${BUNDLE_OUTPUT}/origin.jsbundle.map --dev=true`
+  )
+
+  execSync(
+    `METRO_TREE_SHAKING_CACHE_ROOT=${METRO_TREE_SHAKING_CACHE_ROOT} react-native bundle --platform=native --entry-file=${ENTRY_FILE} --bundle-output=${BUNDLE_OUTPUT}/optimize.jsbundle --sourcemap-output=${BUNDLE_OUTPUT}/optimize.jsbundle.map --dev=true`
+  )
+
+  const originContent = fs.readFileSync(path.join(OUTPUT_ROOT, 'origin.jsbundle'), { encoding: 'utf8' })
+  const optimizedContent = fs.readFileSync(path.join(OUTPUT_ROOT, 'optimize.jsbundle'), { encoding: 'utf8' })
+  const diffs = JSON.stringify(
+    diffLines(originContent, optimizedContent, {
+      ignoreWhitespace: true,
+    }).filter((item) => item.added || item.removed),
+    null,
+    '\t'
+  )
+  expect(diffs).toMatchSnapshot()
+})

--- a/packages/metro-plugin-tree-shaking/__test__/exclude.ts
+++ b/packages/metro-plugin-tree-shaking/__test__/exclude.ts
@@ -1,0 +1,3 @@
+import { add } from './libs/exclude/math'
+
+console.log(add(1, 2))

--- a/packages/metro-plugin-tree-shaking/__test__/libs/exclude/add.js
+++ b/packages/metro-plugin-tree-shaking/__test__/libs/exclude/add.js
@@ -1,0 +1,1 @@
+export const add = (a, b) => a + b

--- a/packages/metro-plugin-tree-shaking/__test__/libs/exclude/diff.js
+++ b/packages/metro-plugin-tree-shaking/__test__/libs/exclude/diff.js
@@ -1,0 +1,1 @@
+export const diff = (a, b) => a - b

--- a/packages/metro-plugin-tree-shaking/__test__/libs/exclude/math.js
+++ b/packages/metro-plugin-tree-shaking/__test__/libs/exclude/math.js
@@ -1,0 +1,2 @@
+export { add } from './add'
+export { diff } from './diff'

--- a/packages/metro-plugin-tree-shaking/babel.config.js
+++ b/packages/metro-plugin-tree-shaking/babel.config.js
@@ -9,7 +9,7 @@ module.exports =
       }
     : /** react-native */ {
         presets: [
-          ["./tree-shaking-preset"],
+          ["./tree-shaking-preset", { excludePatterns: [new RegExp('/exclude/')] }],
           ["module:metro-react-native-babel-preset", {}],
         ],
         env: {


### PR DESCRIPTION
 treeShaking support `excludePatterns` optional paramater

Example:

```js [babel.config.js]
module.exports = {
  presets: [['module:@xhsfe/metro-plugin-tree-shaking', { excludePatterns: [new RegExp('/react/')] }]],
}